### PR TITLE
Add a repository dispatch for automatic testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,8 @@ on:
   workflow_dispatch:
   schedule: # Run every 3 hours starting at 10 minutes past the hour to avoid congestion (runs only on main branch).
     - cron: '10 */3 * * *'
+  repository_dispatch: # Triggered by the "run plugin tests" workflow in the main repo (runs only on main branch).
+    types: [run-plugin-tests]
 
 jobs:
   build:


### PR DESCRIPTION
Related to https://github.com/CUQI-DTU/CUQIpy/issues/114

This adds a so-called repository dispatch which allows one to run the tests remotely through curl. The use-case is to have CUQIpy main repo automatically run tests on the plugins after changes happen to main.