### PR TITLE
Remove testing schedule and update name of repo dispatch type

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,10 +6,8 @@ on:
       - main
   pull_request:
   workflow_dispatch:
-  schedule: # Run every 3 hours starting at 10 minutes past the hour to avoid congestion (runs only on main branch).
-    - cron: '10 */3 * * *'
-  repository_dispatch: # Triggered by the "run plugin tests" workflow in the main repo (runs only on main branch).
-    types: [run-plugin-tests]
+  repository_dispatch: # Triggered when CUQIpy updates via PyPI (runs only on main branch).
+    types: [run-tests-on-cuqipy-update]
 
 jobs:
   build:


### PR DESCRIPTION
No need to do scheduled testing now. Tests get triggered when CUQIpy updates on PyPI (or test PyPI)